### PR TITLE
Bump mongoose from 5.x to 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "supertest": "^6.1.6"
   },
   "peerDependencies": {
-    "mongoose": "5.x",
+    "mongoose": "6.x",
     "express": "4.x"
   }
 }


### PR DESCRIPTION
When attempting to run an 'npm audit fix' on the formio project, it reports an upstream dependency conflict in this package between 5.x and 6.x versions.